### PR TITLE
Added code to properly escape strings inside json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+* There was an issue with prompts that had escape characters in the strings. Fixed this with an extra pass over inner strings of jsons that writes out the escape characters properly. https://github.com/hexthedev/OpenAi-Api-Unity/issues/7

--- a/Runtime/Scripts/Core/Base/AApiResource.cs
+++ b/Runtime/Scripts/Core/Base/AApiResource.cs
@@ -210,7 +210,10 @@ namespace OpenAi.Api.V1
             where TRequest : AModelV1, new()
         {
             HttpClient client = PrepareClient();
-            StringContent stringContent = new StringContent(request.ToJson(), Encoding.UTF8, "application/json");
+
+            string content = request.ToJson();
+            StringContent stringContent = new StringContent(content, Encoding.UTF8, "application/json");
+
             HttpResponseMessage response = await client.PostAsync(Url, stringContent);
             return response;
         }

--- a/Runtime/Scripts/Json/Serialization/JsonBuilder.cs
+++ b/Runtime/Scripts/Json/Serialization/JsonBuilder.cs
@@ -71,6 +71,20 @@ namespace OpenAi.Json
         }
 
         /// <summary>
+        /// if not null, add string to json
+        /// </summary>
+        /// <param name="name"></param>
+        /// <param name="val"></param>
+        public void Add(string name, string val)
+        {
+            if (val != null)
+            {
+                _sb.Append($"{_prefix}\"{name}\":{GetJsonString(val)}");
+                _shouldAddComma = true;
+            }
+        }
+
+        /// <summary>
         /// if not null, adds object to json by naively casting val to string
         /// </summary>
         /// <param name="name"></param>
@@ -99,13 +113,13 @@ namespace OpenAi.Json
                 switch (valActual)
                 {
                     case string s:
-                        valString = $"\"{s}\"";
+                        valString = GetJsonString(s);
                         break;
                     case string[] a:
                         string[] arr = new string[a.Length];
                         for(int i = 0; i<a.Length; i++)
                         {
-                            arr[i] = $"\"{a[i]}\"";
+                            arr[i] = GetJsonString(a[i]);
                         }
                         valString = $"[{string.Join(",", arr)}]";
                         break;
@@ -178,7 +192,7 @@ namespace OpenAi.Json
             string[] strings = new string[value.Length];
             for (int i = 0; i < value.Length; i++)
             {
-                strings[i] = $"\"{value[i]}\"";
+                strings[i] = GetJsonString(value[i]);
             }
             _sb.Append(string.Join(",", strings));
             EndList();
@@ -193,6 +207,37 @@ namespace OpenAi.Json
         public override string ToString()
         {
             return _sb.ToString();
+        }
+
+        private string GetJsonString(string s) => $"\"{ProcessString(s)}\"";
+
+        private string ProcessString(string json)
+        {
+            StringBuilder sb = new StringBuilder();
+
+            for(int i = 0; i<json.Length; i++)
+            {
+                sb.Append(ProcessJsonStringCharacter(json[i]));
+            }
+
+            return sb.ToString();
+        }
+
+        private string ProcessJsonStringCharacter(char character)
+        {
+            switch (character) 
+            { 
+                case '\a': return "\\a";
+                case '\b': return "\\b";
+                case '\t': return "\\t";
+                case '\r': return "\\r";
+                case '\v': return "\\v";
+                case '\f': return "\\f";
+                case '\n': return "\\n";
+                case '\\': return "\\\\";
+            }
+
+            return $"{character}";
         }
     }
 }

--- a/Tests/Runtime/Scripts/Core/V1/V1BugTests.cs
+++ b/Tests/Runtime/Scripts/Core/V1/V1BugTests.cs
@@ -1,0 +1,31 @@
+﻿using NUnit.Framework;
+
+using OpenAi.Api.V1;
+using System.Collections;
+using UnityEngine.TestTools;
+
+namespace OpenAi.Api.Test
+{
+    public class V1BugTests
+    {
+        [UnityTest]
+        // Issue: https://github.com/hexthedev/OpenAi-Api-Unity/issues/7
+        // Prompts weren't working with escape characters
+        public IEnumerator Issue7_EscapeCharacterBug()
+        {
+            TestManager test = TestManager.Instance;
+            OpenAiApiV1 api = test.CleanAndProvideApi();
+
+            ApiResult<CompletionV1> result = null;
+            yield return api.Engines.Engine("ada").Completions.CreateCompletionCoroutine(
+                test, 
+                new CompletionRequestV1() { prompt = "something\r\n", max_tokens = 8 },
+                (r) => result = r
+            );
+
+            Assert.IsNotNull(result);
+            Assert.That(result.IsSuccess);
+            Assert.IsNotNull(result.Result);
+        }
+    }
+}

--- a/Tests/Runtime/Scripts/Core/V1/V1BugTests.cs.meta
+++ b/Tests/Runtime/Scripts/Core/V1/V1BugTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 86b352fb947b61a41a1d13d30b0e844d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "com.openai.api.unity",
-    "version": "0.1.1",
+    "version": "0.1.2",
     "displayName": "OpenAi Api Unity",
     "description": "An OpenAi Api for the Unity Engine",
     "unity": "2019.4",


### PR DESCRIPTION
There was an issue with prompts that had escape characters in the strings. Fixed this with an extra pass over inner strings of jsons that writes out the escape characters properly.

Issues Solved: #7 