### PR TITLE
Fix for a memory leak issue

### DIFF
--- a/Runtime/Scripts/Api/Base/AApiResource.cs
+++ b/Runtime/Scripts/Api/Base/AApiResource.cs
@@ -212,6 +212,7 @@ namespace OpenAi.Api.V1
             AddJsonToUnityWebRequest(client, request.ToJson());
 
             await client.SendWebRequest();
+            client.uploadHandler.Dispose();
             return client;
         }
 


### PR DESCRIPTION
Disposes the UnityWebRequest UploadHandler after use, in order to fix a memory leak issue
#42