### PR TITLE
Completion Arguments stop property, now accepts an array on the editor

### DIFF
--- a/Runtime/Config/DefaultCompletionArgs.asset
+++ b/Runtime/Config/DefaultCompletionArgs.asset
@@ -15,6 +15,10 @@ MonoBehaviour:
   max_tokens: 32
   temperature: 0.7
   top_p: 1
-  stop: 
+  stop:
+  - 
+  - 
+  - 
+  - 
   presences_penalty: 0
   frequency_penalty: 0

--- a/Runtime/Scripts/Api/Utility/StringOrArray.cs
+++ b/Runtime/Scripts/Api/Utility/StringOrArray.cs
@@ -18,8 +18,13 @@ namespace OpenAi.Api.V1
         /// <param name="strings"></param>
         public StringOrArray(params string[] strings)
         {
-            if(strings != null)
+            if (strings != null)
             {
+                //Nullifies the empty strings in the array
+                for (var i = 0; i < strings.Length; i++)
+                {
+                    strings[i] = string.IsNullOrEmpty(strings[i]) ? null : strings[i];
+                }
                 _elements = new List<string>(strings);
             }
         }

--- a/Runtime/Scripts/Json/Serialization/JsonBuilder.cs
+++ b/Runtime/Scripts/Json/Serialization/JsonBuilder.cs
@@ -3,7 +3,6 @@ using OpenAi.Api.V1;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
-using System.Linq;
 using System.Text;
 
 namespace OpenAi.Json

--- a/Runtime/Scripts/Json/Serialization/JsonBuilder.cs
+++ b/Runtime/Scripts/Json/Serialization/JsonBuilder.cs
@@ -3,6 +3,7 @@ using OpenAi.Api.V1;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Linq;
 using System.Text;
 
 namespace OpenAi.Json
@@ -121,10 +122,14 @@ namespace OpenAi.Json
                         valString = GetJsonString(s);
                         break;
                     case string[] a:
-                        string[] arr = new string[a.Length];
+                        //We send a list because we don't know how many non-null elements we have on the array
+                        List<string> arr = new List<string>();
                         for(int i = 0; i<a.Length; i++)
                         {
-                            arr[i] = GetJsonString(a[i]);
+                            if (a[i] != null)
+                            {
+                                arr.Add(GetJsonString(a[i]));
+                            }
                         }
                         valString = $"[{string.Join(",", arr)}]";
                         break;

--- a/Runtime/Scripts/Unity/V1/Completer/SOCompletionArgsV1.cs
+++ b/Runtime/Scripts/Unity/V1/Completer/SOCompletionArgsV1.cs
@@ -20,7 +20,7 @@ namespace OpenAi.Unity.V1
         public float top_p = 1;
 
         [Tooltip("Up to 4 sequences where the API will stop generating further tokens. The returned text will not contain the stop sequence.")]
-        public string stop;
+        public string[] stop = new string[4];
 
         [Tooltip("Number between 0 and 1 that penalizes new tokens based on whether they appear in the text so far. Increases the model's likelihood to talk about new topics. https://beta.openai.com/docs/api-reference/parameter-details/>")]
         public float presences_penalty = 0;
@@ -35,7 +35,7 @@ namespace OpenAi.Unity.V1
                 max_tokens = max_tokens,
                 temperature = temperature,
                 top_p = top_p,
-                stop = string.IsNullOrEmpty(stop) ? null : stop,
+                stop = stop,
                 frequency_penalty = frequency_penalty
             };
         }


### PR DESCRIPTION
Changed the Completion Arguments scriptable object, to work with string array for the stop sequences
#44