### PR TITLE
Fix escaping character not appended correctly

### DIFF
--- a/Runtime/Scripts/Json/Deserialization/LexicalAnalysis/JsonLexer.cs
+++ b/Runtime/Scripts/Json/Deserialization/LexicalAnalysis/JsonLexer.cs
@@ -44,7 +44,7 @@ namespace OpenAi.Json
                     case ECharacterAnalyzerResponse.IncludeEscapeCharacter:
                         if (!generatingToken) generatingToken = true;
                         sb.Append(json[i]);
-                        sb.Append(json[i++]);
+                        sb.Append(json[++i]);
                         break;
 
                     case ECharacterAnalyzerResponse.ExcludeCharacter:


### PR DESCRIPTION
The escaping character was not handled correctly because the array index was not advanced.